### PR TITLE
Add structured data for site and blog

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,6 +6,23 @@
     <title>Blog do Palavrinha</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "Blog",
+            "name": "Blog do Palavrinha",
+            "url": "https://jogopalavrinha.com/blog.html",
+            "publisher": {
+                "@type": "Organization",
+                "name": "Palavrinha",
+                "url": "https://jogopalavrinha.com/",
+                "logo": {
+                    "@type": "ImageObject",
+                    "url": "https://jogopalavrinha.com/palavrinha.png"
+                }
+            }
+        }
+    </script>
     <style>
         body {
             font-family: 'Inter', sans-serif;

--- a/index.html
+++ b/index.html
@@ -13,6 +13,35 @@
     <meta property="og:image" content="https://jogopalavrinha.com/share-img.png" />
     <meta property="og:url" content="https://jogopalavrinha.com/" />
     <meta property="og:type" content="website" />
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            "name": "Palavrinha",
+            "url": "https://jogopalavrinha.com/",
+            "potentialAction": {
+                "@type": "SearchAction",
+                "target": "https://jogopalavrinha.com/?desafio={palavra}",
+                "query-input": "required name=palavra"
+            }
+        }
+    </script>
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "VideoGame",
+            "name": "Palavrinha",
+            "url": "https://jogopalavrinha.com/",
+            "applicationCategory": "Game",
+            "operatingSystem": "Web browser",
+            "image": [
+                "https://jogopalavrinha.com/share-img.png"
+            ],
+            "screenshot": [
+                "https://jogopalavrinha.com/share-img.png"
+            ]
+        }
+    </script>
     <style>
         :root {
             --cor-fundo: #ffffff;


### PR DESCRIPTION
## Summary
- add JSON-LD metadata describing the Palavrinha site as a WebSite with search support
- describe the game experience as a VideoGame with platform and screenshots
- include Blog structured data for the blog page with publisher information

## Testing
- ⚠️ `npx structured-data-testing-tool --version` *(fails with npm 403 when trying to fetch the package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c3d836ac8325a21f9a0d6d0cc126